### PR TITLE
test: cover root and gen command config wiring

### DIFF
--- a/cmd/af/gen/gen_test.go
+++ b/cmd/af/gen/gen_test.go
@@ -1,0 +1,58 @@
+package gen
+
+import (
+	"testing"
+
+	"github.com/omniaura/agentflow/cfg"
+	"github.com/spf13/viper"
+)
+
+func TestCMDDefaults(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	cfg.MaxLineLen = 0
+
+	cmd := CMD()
+
+	if cmd.Use != "gen" {
+		t.Fatalf("expected command use gen, got %q", cmd.Use)
+	}
+	if cfg.MaxLineLen != 80 {
+		t.Fatalf("expected default max line len 80, got %d", cfg.MaxLineLen)
+	}
+
+	maxLineLenFlag := cmd.PersistentFlags().Lookup("max-line-len")
+	if maxLineLenFlag == nil {
+		t.Fatal("expected max-line-len flag")
+	}
+	if maxLineLenFlag.DefValue != "80" {
+		t.Fatalf("expected max-line-len default 80, got %q", maxLineLenFlag.DefValue)
+	}
+
+	if got := viper.GetInt("max-line-len"); got != 80 {
+		t.Fatalf("expected viper max-line-len 80, got %d", got)
+	}
+
+	if _, _, err := cmd.Find([]string{"prompts"}); err != nil {
+		t.Fatalf("expected prompts subcommand, got error %v", err)
+	}
+}
+
+func TestCMDParsesMaxLineLenFlag(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	cfg.MaxLineLen = 0
+
+	cmd := CMD()
+	err := cmd.PersistentFlags().Set("max-line-len", "120")
+	if err != nil {
+		t.Fatalf("set max-line-len flag: %v", err)
+	}
+
+	if cfg.MaxLineLen != 120 {
+		t.Fatalf("expected parsed max line len 120, got %d", cfg.MaxLineLen)
+	}
+	if got := viper.GetInt("max-line-len"); got != 120 {
+		t.Fatalf("expected viper max-line-len 120, got %d", got)
+	}
+}

--- a/cmd/af/main.go
+++ b/cmd/af/main.go
@@ -27,29 +27,32 @@ import (
 	"github.com/spf13/viper"
 )
 
-var Root = &cobra.Command{
-	Version:          cfg.Version, // This line will be updated by the sync-version script
-	Use:              "af",
-	Short:            "AgentFlow CLI",
-	Long:             "AgentFlow is a CLI for bootstrapping AI agents.",
-	PersistentPreRun: func(cmd *cobra.Command, args []string) { logger.Setup() },
+func newRootCommand() *cobra.Command {
+	root := &cobra.Command{
+		Version:          cfg.Version, // This line will be updated by the sync-version script
+		Use:              "af",
+		Short:            "AgentFlow CLI",
+		Long:             "AgentFlow is a CLI for bootstrapping AI agents.",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) { logger.Setup() },
+	}
+
+	root.PersistentFlags().StringVar(&cfg.FlagLogLevel, "log", "debug", "Log level")
+	root.AddCommand(gen.CMD())
+	root.AddCommand(lsp.CMD())
+
+	// Bind persistent flags to viper after all commands are added.
+	viper.BindPFlag("log", root.PersistentFlags().Lookup("log"))
+
+	return root
 }
 
 func main() {
 	cobra.OnInitialize(cfg.InitConfig)
 
-	Root.PersistentFlags().StringVar(&cfg.FlagLogLevel, "log", "debug", "Log level")
-
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	Root.AddCommand(gen.CMD())
-	Root.AddCommand(lsp.CMD())
-
-	// Bind persistent flags to viper after all commands are added
-	viper.BindPFlag("log", Root.PersistentFlags().Lookup("log"))
-
-	err := Root.ExecuteContext(ctx)
+	err := newRootCommand().ExecuteContext(ctx)
 	assert.NoError(err)
 }

--- a/cmd/af/main_test.go
+++ b/cmd/af/main_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/omniaura/agentflow/cfg"
+	"github.com/spf13/viper"
+)
+
+func TestNewRootCommandDefaults(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	cfg.FlagLogLevel = ""
+
+	cmd := newRootCommand()
+
+	if cmd.Use != "af" {
+		t.Fatalf("expected command use af, got %q", cmd.Use)
+	}
+	if cmd.Version != cfg.Version {
+		t.Fatalf("expected version %q, got %q", cfg.Version, cmd.Version)
+	}
+
+	logFlag := cmd.PersistentFlags().Lookup("log")
+	if logFlag == nil {
+		t.Fatal("expected log flag")
+	}
+	if logFlag.DefValue != "debug" {
+		t.Fatalf("expected log default debug, got %q", logFlag.DefValue)
+	}
+	if cfg.FlagLogLevel != "debug" {
+		t.Fatalf("expected cfg.FlagLogLevel debug, got %q", cfg.FlagLogLevel)
+	}
+
+	if got := viper.GetString("log"); got != "debug" {
+		t.Fatalf("expected viper log debug, got %q", got)
+	}
+
+	if _, _, err := cmd.Find([]string{"gen"}); err != nil {
+		t.Fatalf("expected gen subcommand, got error %v", err)
+	}
+	if _, _, err := cmd.Find([]string{"lsp"}); err != nil {
+		t.Fatalf("expected lsp subcommand, got error %v", err)
+	}
+	if len(cmd.Commands()) != 2 {
+		t.Fatalf("expected 2 subcommands, got %d", len(cmd.Commands()))
+	}
+}
+
+func TestNewRootCommandParsesLogFlag(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	cfg.FlagLogLevel = ""
+
+	cmd := newRootCommand()
+	err := cmd.PersistentFlags().Set("log", "warn")
+	if err != nil {
+		t.Fatalf("set log flag: %v", err)
+	}
+
+	if cfg.FlagLogLevel != "warn" {
+		t.Fatalf("expected cfg.FlagLogLevel warn, got %q", cfg.FlagLogLevel)
+	}
+	if got := viper.GetString("log"); got != "warn" {
+		t.Fatalf("expected viper log warn, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add root command coverage for `af` defaults, subcommand wiring, and `log` Viper binding
- add `gen` command coverage for `max-line-len` defaults, parsing, and `prompts` registration
- refactor CLI bootstrap to build the root command through a helper so tests can exercise the real wiring without mutating global state

## Testing
- `go test ./...`
