### PR TITLE
feat: add demo init command

### DIFF
--- a/cmd/af/demo/demo.go
+++ b/cmd/af/demo/demo.go
@@ -1,0 +1,181 @@
+/*
+Copyright © 2024 Omni Aura peyton@omniaura.co
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package demo
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/omniaura/agentflow/pkg/assert"
+	"github.com/spf13/cobra"
+)
+
+var output io.Writer = os.Stdout
+
+func CMD() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "demo",
+		Short: "Create AgentFlow demo projects",
+	}
+	cmd.AddCommand(initCMD())
+	return cmd
+}
+
+func initCMD() *cobra.Command {
+	return &cobra.Command{
+		Use:   "init <dir>",
+		Short: "Create a runnable AgentFlow demo project",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			dir := args[0]
+			assert.NoError(initDemo(dir))
+			_, err := fmt.Fprintf(output, `Created AgentFlow demo in %s
+
+Next:
+  cd %s
+  af gen prompts --dir prompts
+  go run .
+
+Editor:
+  Open this folder in VS Code and install the AgentFlow extension for .af highlighting.
+`, dir, dir)
+			assert.NoError(err)
+		},
+	}
+}
+
+func initDemo(dir string) error {
+	if err := ensureWritableDemoDir(dir); err != nil {
+		return err
+	}
+
+	files := map[string]string{
+		"go.mod":               goModContent,
+		"README.md":            readmeContent,
+		"main.go":              mainGoContent,
+		"prompts/assistant.af": assistantAFContent,
+	}
+
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ensureWritableDemoDir(dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return os.MkdirAll(dir, 0755)
+		}
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("demo path %q already exists and is not a directory", dir)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	if len(entries) > 0 {
+		return fmt.Errorf("demo directory %q already exists and is not empty", dir)
+	}
+
+	return nil
+}
+
+const goModContent = `module agentflow-demo
+
+go 1.25.0
+`
+
+const readmeContent = "# AgentFlow Demo\n" + `
+
+This project demonstrates AgentFlow prompt templates with titles, typed variables, nested variables, conditionals, and comparisons.
+
+## Run
+
+` + "```sh" + `
+af gen prompts --dir prompts
+go run .
+` + "```" + `
+
+Open ` + "`prompts/assistant.af`" + ` in VS Code with the AgentFlow extension installed for syntax highlighting.
+`
+
+const mainGoContent = `package main
+
+import (
+	"fmt"
+
+	"agentflow-demo/prompts"
+)
+
+func main() {
+	briefing := prompts.SystemBriefing{}
+	briefing.Agent.Name = "Ada"
+	briefing.Workspace.Name = "AgentFlow Demo"
+	briefing.Workspace.Production = false
+
+	fmt.Println(briefing.String())
+}
+`
+
+const assistantAFContent = `.title System Briefing
+You are <!agent.name>, an AI assistant for <!workspace.name>.
+
+<?workspace.production bool>
+Treat this as a production environment. Be careful with destructive operations.
+<else>
+This is a sandbox environment. Prefer fast iteration.
+</workspace.production>
+
+.title Task Handoff
+User: <!user.name>
+Plan depth: <!plan.depth int>
+Confidence target: <!confidence float64>
+
+<?plan.depth gte 3>
+Provide a structured plan before editing files.
+<else>
+Keep the response direct and execute the smallest correct change.
+</plan.depth>
+
+<?user.premium bool>
+Use priority model routing for <!user.name>.
+</user.premium>
+
+.title Memory Summary
+Project: <!project.name>
+Owner: <!project.owner.name>
+Open issues: <!project.open_issues int>
+
+<?project.open_issues gt 0>
+Mention the highest-risk open issue before implementation.
+<else>
+No known blockers.
+</project.open_issues>
+`

--- a/cmd/af/demo/demo_test.go
+++ b/cmd/af/demo/demo_test.go
@@ -1,0 +1,81 @@
+package demo
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	genprompts "github.com/omniaura/agentflow/cmd/af/gen/prompts"
+	"github.com/omniaura/agentflow/pkg/assert/require"
+	"github.com/omniaura/agentflow/pkg/ast"
+)
+
+func TestInitDemoCreatesRunnableProject(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "agentflow-demo")
+
+	require.NoError(t, initDemo(dir))
+
+	expectedFiles := []string{
+		"go.mod",
+		"README.md",
+		"main.go",
+		"prompts/assistant.af",
+	}
+	for _, name := range expectedFiles {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Fatalf("expected %s to exist: %v", name, err)
+		}
+	}
+
+	promptPath := filepath.Join(dir, "prompts", "assistant.af")
+	promptContent, err := os.ReadFile(promptPath)
+	require.NoError(t, err)
+	parsed, err := ast.NewFile("assistant.af", promptContent)
+	require.NoError(t, err)
+	if len(parsed.Prompts) != 3 {
+		t.Fatalf("expected 3 demo prompts, got %d", len(parsed.Prompts))
+	}
+
+	cmd := genprompts.CMD()
+	cmd.SetArgs([]string{"--dir", filepath.Join(dir, "prompts")})
+	require.NoError(t, cmd.Execute())
+
+	if _, err := os.Stat(filepath.Join(dir, "prompts", "assistant_af.go")); err != nil {
+		t.Fatalf("expected generated assistant_af.go to exist: %v", err)
+	}
+}
+
+func TestInitDemoRejectsNonEmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "existing.txt"), []byte("keep me"), 0644))
+
+	err := initDemo(dir)
+	if err == nil {
+		t.Fatal("expected non-empty directory error")
+	}
+	if !strings.Contains(err.Error(), "already exists and is not empty") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestInitCommandPrintsNextSteps(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "demo")
+	originalOutput := output
+	var out bytes.Buffer
+	output = &out
+	t.Cleanup(func() { output = originalOutput })
+
+	cmd := initCMD()
+	cmd.SetArgs([]string{dir})
+	require.NoError(t, cmd.Execute())
+
+	text := out.String()
+	if !strings.Contains(text, "af gen prompts --dir prompts") {
+		t.Fatalf("expected generation hint, got %q", text)
+	}
+	if !strings.Contains(text, "go run .") {
+		t.Fatalf("expected run hint, got %q", text)
+	}
+}

--- a/cmd/af/main.go
+++ b/cmd/af/main.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	"github.com/omniaura/agentflow/cfg"
+	"github.com/omniaura/agentflow/cmd/af/demo"
 	"github.com/omniaura/agentflow/cmd/af/gen"
 	"github.com/omniaura/agentflow/cmd/af/lsp"
 	"github.com/omniaura/agentflow/pkg/assert"
@@ -37,6 +38,7 @@ func newRootCommand() *cobra.Command {
 	}
 
 	root.PersistentFlags().StringVar(&cfg.FlagLogLevel, "log", "debug", "Log level")
+	root.AddCommand(demo.CMD())
 	root.AddCommand(gen.CMD())
 	root.AddCommand(lsp.CMD())
 

--- a/cmd/af/main_test.go
+++ b/cmd/af/main_test.go
@@ -36,14 +36,17 @@ func TestNewRootCommandDefaults(t *testing.T) {
 		t.Fatalf("expected viper log debug, got %q", got)
 	}
 
+	if _, _, err := cmd.Find([]string{"demo"}); err != nil {
+		t.Fatalf("expected demo subcommand, got error %v", err)
+	}
 	if _, _, err := cmd.Find([]string{"gen"}); err != nil {
 		t.Fatalf("expected gen subcommand, got error %v", err)
 	}
 	if _, _, err := cmd.Find([]string{"lsp"}); err != nil {
 		t.Fatalf("expected lsp subcommand, got error %v", err)
 	}
-	if len(cmd.Commands()) != 2 {
-		t.Fatalf("expected 2 subcommands, got %d", len(cmd.Commands()))
+	if len(cmd.Commands()) != 3 {
+		t.Fatalf("expected 3 subcommands, got %d", len(cmd.Commands()))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `af demo init <dir>` as a top-level scaffold command for a runnable demo project.
- Emit `go.mod`, `README.md`, `main.go`, and `prompts/assistant.af` covering titles, typed/nested vars, conditionals, and comparisons.
- Cover scaffold creation, non-empty directory rejection, `.af` parsing, and post-init `af gen prompts` generation in tests.

Closes #9.

## Tests

- `go test ./...`
- `go run ./cmd/af demo init "$tmpdir/demo" && go run ./cmd/af gen prompts --dir "$tmpdir/demo/prompts" && go -C "$tmpdir/demo" run .`
