### PR TITLE
fix(ci): repair Go Coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,9 +4,18 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: write
+
 jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
     - name: Update coverage report
       uses: ncruces/go-coverage-report@main


### PR DESCRIPTION
## Summary

- add an explicit checkout before the Go Coverage action runs
- install the Go version from `go.mod` so coverage tooling like `covdata` is available
- grant content write permission for the wiki coverage update

## Validation

- `git diff --check`
- `go test ./...`

Closes #67.
