### PR TITLE
feat(fmt): canonical formatter for .af files

### DIFF
--- a/cmd/af/fmt/fmt.go
+++ b/cmd/af/fmt/fmt.go
@@ -1,0 +1,151 @@
+/*
+Copyright © 2024 Omni Aura peyton@omniaura.co
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package fmtcmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/omniaura/agentflow/pkg/assert"
+	"github.com/omniaura/agentflow/pkg/format"
+	"github.com/spf13/cobra"
+)
+
+var output io.Writer = os.Stdout
+
+type options struct {
+	write bool
+	check bool
+	dir   string
+}
+
+func CMD() *cobra.Command {
+	opts := &options{}
+	cmd := &cobra.Command{
+		Use:   "fmt <files...>",
+		Short: "Format .af files",
+		Args: func(cmd *cobra.Command, args []string) error {
+			return opts.validate(args)
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			assert.NoError(run(opts, args))
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.write, "write", false, "Write formatted output back to files")
+	cmd.Flags().BoolVar(&opts.check, "check", false, "Exit non-zero and list files that are not formatted")
+	cmd.Flags().StringVar(&opts.dir, "dir", "", "Recursively format .af files in a directory")
+	return cmd
+}
+
+func (opts options) validate(args []string) error {
+	if opts.write && opts.check {
+		return fmt.Errorf("--write and --check are mutually exclusive")
+	}
+	if opts.dir != "" && len(args) > 0 {
+		return fmt.Errorf("--dir cannot be combined with explicit files")
+	}
+	if opts.dir == "" && len(args) == 0 {
+		return fmt.Errorf("provide a file or --dir")
+	}
+	if opts.dir == "" && !opts.write && !opts.check && len(args) != 1 {
+		return fmt.Errorf("stdout mode requires exactly one file")
+	}
+	if opts.dir != "" && !opts.write && !opts.check {
+		return fmt.Errorf("--dir requires --write or --check")
+	}
+	return nil
+}
+
+func run(opts *options, args []string) error {
+	files := args
+	if opts.dir != "" {
+		var err error
+		files, err = collectAFFiles(opts.dir)
+		if err != nil {
+			return err
+		}
+	}
+
+	changed := make([]string, 0)
+	for _, file := range files {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			return err
+		}
+		formatted, err := format.Format(file, src)
+		if err != nil {
+			return err
+		}
+
+		if opts.check {
+			if !bytes.Equal(src, formatted) {
+				changed = append(changed, file)
+			}
+			continue
+		}
+
+		if opts.write {
+			if !bytes.Equal(src, formatted) {
+				if err := os.WriteFile(file, formatted, 0644); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+
+		if _, err := output.Write(formatted); err != nil {
+			return err
+		}
+	}
+
+	if opts.check && len(changed) > 0 {
+		for _, file := range changed {
+			if _, err := fmt.Fprintln(output, file); err != nil {
+				return err
+			}
+		}
+		return fmt.Errorf("%d file(s) need formatting", len(changed))
+	}
+
+	return nil
+}
+
+func collectAFFiles(dir string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.Type()&fs.ModeSymlink != 0 {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !d.IsDir() && filepath.Ext(path) == ".af" {
+			files = append(files, path)
+		}
+		return nil
+	})
+	sort.Strings(files)
+	return files, err
+}

--- a/cmd/af/fmt/fmt_test.go
+++ b/cmd/af/fmt/fmt_test.go
@@ -1,0 +1,103 @@
+package fmtcmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omniaura/agentflow/pkg/assert/require"
+)
+
+func TestStdoutModeDoesNotMutateFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prompt.af")
+	original := []byte(".title   Demo\nBody <! name >")
+	require.NoError(t, os.WriteFile(path, original, 0644))
+
+	originalOutput := output
+	var out bytes.Buffer
+	output = &out
+	t.Cleanup(func() { output = originalOutput })
+
+	require.NoError(t, run(&options{}, []string{path}))
+
+	current, err := os.ReadFile(path)
+	require.NoError(t, err)
+	if !bytes.Equal(current, original) {
+		t.Fatalf("expected file to remain unchanged, got %q", string(current))
+	}
+	if !strings.Contains(out.String(), "<!name>") {
+		t.Fatalf("expected formatted stdout, got %q", out.String())
+	}
+}
+
+func TestWriteUpdatesFiles(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prompt.af")
+	require.NoError(t, os.WriteFile(path, []byte(".title   Demo\nBody <! name >"), 0644))
+
+	require.NoError(t, run(&options{write: true}, []string{path}))
+
+	current, err := os.ReadFile(path)
+	require.NoError(t, err)
+	if string(current) != ".title Demo\n\nBody <!name>\n" {
+		t.Fatalf("unexpected file content: %q", string(current))
+	}
+}
+
+func TestCheckCleanSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prompt.af")
+	require.NoError(t, os.WriteFile(path, []byte(".title Demo\n\nBody <!name>\n"), 0644))
+
+	require.NoError(t, run(&options{check: true}, []string{path}))
+}
+
+func TestCheckDirtyFailsAndListsPaths(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "prompt.af")
+	require.NoError(t, os.WriteFile(path, []byte(".title   Demo\nBody <! name >"), 0644))
+
+	originalOutput := output
+	var out bytes.Buffer
+	output = &out
+	t.Cleanup(func() { output = originalOutput })
+
+	err := run(&options{check: true}, []string{path})
+	if err == nil {
+		t.Fatal("expected check failure")
+	}
+	if !strings.Contains(out.String(), path) {
+		t.Fatalf("expected changed path in output, got %q", out.String())
+	}
+}
+
+func TestValidateRejectsWriteAndCheck(t *testing.T) {
+	err := (options{write: true, check: true}).validate([]string{"prompt.af"})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDirCollectsAFFiles(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.af"), []byte(".title   A"), 0644))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "nested"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "nested", "b.af"), []byte(".title   B"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ignore.txt"), []byte(".title   C"), 0644))
+
+	require.NoError(t, run(&options{write: true, dir: dir}, nil))
+
+	for _, name := range []string{"a.af", filepath.Join("nested", "b.af")} {
+		content, err := os.ReadFile(filepath.Join(dir, name))
+		require.NoError(t, err)
+		if strings.Contains(string(content), "   ") {
+			t.Fatalf("expected %s to be formatted, got %q", name, string(content))
+		}
+	}
+}

--- a/cmd/af/main.go
+++ b/cmd/af/main.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/omniaura/agentflow/cfg"
 	"github.com/omniaura/agentflow/cmd/af/demo"
+	fmtcmd "github.com/omniaura/agentflow/cmd/af/fmt"
 	"github.com/omniaura/agentflow/cmd/af/gen"
 	"github.com/omniaura/agentflow/cmd/af/lsp"
 	"github.com/omniaura/agentflow/pkg/assert"
@@ -39,6 +40,7 @@ func newRootCommand() *cobra.Command {
 
 	root.PersistentFlags().StringVar(&cfg.FlagLogLevel, "log", "debug", "Log level")
 	root.AddCommand(demo.CMD())
+	root.AddCommand(fmtcmd.CMD())
 	root.AddCommand(gen.CMD())
 	root.AddCommand(lsp.CMD())
 

--- a/cmd/af/main_test.go
+++ b/cmd/af/main_test.go
@@ -39,14 +39,17 @@ func TestNewRootCommandDefaults(t *testing.T) {
 	if _, _, err := cmd.Find([]string{"demo"}); err != nil {
 		t.Fatalf("expected demo subcommand, got error %v", err)
 	}
+	if _, _, err := cmd.Find([]string{"fmt"}); err != nil {
+		t.Fatalf("expected fmt subcommand, got error %v", err)
+	}
 	if _, _, err := cmd.Find([]string{"gen"}); err != nil {
 		t.Fatalf("expected gen subcommand, got error %v", err)
 	}
 	if _, _, err := cmd.Find([]string{"lsp"}); err != nil {
 		t.Fatalf("expected lsp subcommand, got error %v", err)
 	}
-	if len(cmd.Commands()) != 3 {
-		t.Fatalf("expected 3 subcommands, got %d", len(cmd.Commands()))
+	if len(cmd.Commands()) != 4 {
+		t.Fatalf("expected 4 subcommands, got %d", len(cmd.Commands()))
 	}
 }
 

--- a/pkg/format/format.go
+++ b/pkg/format/format.go
@@ -1,0 +1,196 @@
+/*
+Copyright © 2024 Omni Aura peyton@omniaura.co
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package format
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+
+	"github.com/omniaura/agentflow/pkg/token"
+	"github.com/omniaura/agentflow/pkg/token/kind"
+)
+
+var elsePattern = regexp.MustCompile(`<\s*else\s*>`)
+
+func Format(name string, src []byte) ([]byte, error) {
+	normalized := normalizeLineEndings(src)
+	tokens, err := token.Tokenize(normalized)
+	if err != nil {
+		return nil, err
+	}
+
+	directives := elsePattern.ReplaceAll(normalizeDirectives(tokens, normalized), []byte("<else>"))
+	lines := normalizeStructuralLines(string(directives))
+	return []byte(lines), nil
+}
+
+func normalizeLineEndings(src []byte) []byte {
+	src = bytes.ReplaceAll(src, []byte("\r\n"), []byte("\n"))
+	return bytes.ReplaceAll(src, []byte("\r"), []byte("\n"))
+}
+
+func normalizeDirectives(tokens token.Slice, src []byte) []byte {
+	var out strings.Builder
+	out.Grow(len(src) + 1)
+
+	for i := 0; i < len(tokens); i++ {
+		tok := tokens[i]
+		switch tok.Kind {
+		case kind.TitleDirective:
+			i = writeTitle(&out, tokens, src, i)
+		case kind.OpenBracket:
+			if next, ok := peek(tokens, i+1); ok {
+				switch next.Kind {
+				case kind.DirectiveVar:
+					i = writeTag(&out, tokens, src, i, "<!", ">", true)
+				case kind.DirectiveCond:
+					i = writeTag(&out, tokens, src, i, "<?", ">", true)
+				case kind.DirectiveEnd:
+					i = writeTag(&out, tokens, src, i, "</", ">", false)
+				case kind.DirectiveElse:
+					out.WriteString("<else>")
+					i = skipToClose(tokens, i)
+				default:
+					out.Write(tok.Get(src))
+				}
+			} else {
+				out.Write(tok.Get(src))
+			}
+		default:
+			out.Write(tok.Get(src))
+		}
+	}
+
+	return []byte(out.String())
+}
+
+func writeTitle(out *strings.Builder, tokens token.Slice, src []byte, start int) int {
+	out.WriteString(".title")
+
+	i := start + 1
+	if i < len(tokens) && tokens[i].Kind == kind.Whitespace && !strings.Contains(string(tokens[i].Get(src)), "\n") {
+		i++
+	}
+	if i < len(tokens) && tokens[i].Kind == kind.TitleText {
+		title := strings.TrimSpace(string(tokens[i].Get(src)))
+		if title != "" {
+			out.WriteByte(' ')
+			out.WriteString(title)
+		}
+		i++
+	}
+	if i < len(tokens) && tokens[i].Kind == kind.Whitespace && string(tokens[i].Get(src)) == "\n" {
+		out.WriteByte('\n')
+		return i
+	}
+
+	return i - 1
+}
+
+func writeTag(out *strings.Builder, tokens token.Slice, src []byte, start int, prefix, suffix string, keepSpaces bool) int {
+	end := skipToClose(tokens, start)
+	if end <= start+1 || end >= len(tokens) {
+		out.Write(tokens[start].Get(src))
+		return start
+	}
+
+	contentStart := tokens[start+2].Start
+	contentEnd := tokens[end].Start
+	if contentEnd < contentStart {
+		contentEnd = contentStart
+	}
+	parts := strings.Fields(string(src[contentStart:contentEnd]))
+
+	out.WriteString(prefix)
+	if keepSpaces {
+		out.WriteString(strings.Join(parts, " "))
+	} else if len(parts) > 0 {
+		out.WriteString(parts[0])
+	}
+	out.WriteString(suffix)
+	return end
+}
+
+func skipToClose(tokens token.Slice, start int) int {
+	for i := start; i < len(tokens); i++ {
+		if tokens[i].Kind == kind.CloseBracket {
+			return i
+		}
+	}
+	return start
+}
+
+func peek(tokens token.Slice, index int) (token.T, bool) {
+	if index < 0 || index >= len(tokens) {
+		return token.T{}, false
+	}
+	return tokens[index], true
+}
+
+func normalizeStructuralLines(src string) string {
+	lines := strings.Split(src, "\n")
+	for i := range lines {
+		lines[i] = strings.TrimRight(lines[i], " \t")
+	}
+	for len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+
+	out := make([]string, 0, len(lines)+4)
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		if isTitleLine(line) {
+			trimTrailingBlankLines(&out)
+			if hasNonEmptyLine(out) {
+				out = append(out, "")
+			}
+
+			out = append(out, line)
+			for i+1 < len(lines) && lines[i+1] == "" {
+				i++
+			}
+			if i+1 < len(lines) && !isTitleLine(lines[i+1]) {
+				out = append(out, "")
+			}
+			continue
+		}
+
+		out = append(out, line)
+	}
+
+	trimTrailingBlankLines(&out)
+	return strings.Join(out, "\n") + "\n"
+}
+
+func isTitleLine(line string) bool {
+	return line == ".title" || strings.HasPrefix(line, ".title ")
+}
+
+func trimTrailingBlankLines(lines *[]string) {
+	for len(*lines) > 0 && (*lines)[len(*lines)-1] == "" {
+		*lines = (*lines)[:len(*lines)-1]
+	}
+}
+
+func hasNonEmptyLine(lines []string) bool {
+	for _, line := range lines {
+		if line != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/format/format_test.go
+++ b/pkg/format/format_test.go
@@ -1,0 +1,109 @@
+package format
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/omniaura/agentflow/pkg/assert/require"
+)
+
+func TestFormatFixtures(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "already formatted",
+			in: `.title System Prompt
+
+Hello <!user.name>.
+
+<?user.premium bool>
+Premium guidance.
+<else>
+Default guidance.
+</user.premium>
+`,
+			want: `.title System Prompt
+
+Hello <!user.name>.
+
+<?user.premium bool>
+Premium guidance.
+<else>
+Default guidance.
+</user.premium>
+`,
+		},
+		{
+			name: "messy variable spacing",
+			in:   ".title   Greeting   \n\nHello <!  user.name   string  > and <!\tcount\tint\t>.\n",
+			want: `.title Greeting
+
+Hello <!user.name string> and <!count int>.
+`,
+		},
+		{
+			name: "messy conditional spacing",
+			in: `.title Access
+
+<?   plan.depth   gte   3   >
+Plan first.
+<else  >
+Act directly.
+</  plan.depth  >
+`,
+			want: `.title Access
+
+<?plan.depth gte 3>
+Plan first.
+<else>
+Act directly.
+</plan.depth>
+`,
+		},
+		{
+			name: "multiple titles",
+			in: `.title One
+Body one.
+
+
+
+.title    Two
+
+
+Body two.
+`,
+			want: `.title One
+
+Body one.
+
+.title Two
+
+Body two.
+`,
+		},
+		{
+			name: "trailing whitespace and final newline",
+			in:   ".title Demo\r\n\r\nLine with spaces.   \r\nLast line\t",
+			want: ".title Demo\n\nLine with spaces.\nLast line\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Format(tt.name+".af", []byte(tt.in))
+			require.NoError(t, err)
+			if string(got) != tt.want {
+				t.Fatalf("unexpected formatted output:\nwant:\n%q\ngot:\n%q", tt.want, string(got))
+			}
+
+			again, err := Format(tt.name+".af", got)
+			require.NoError(t, err)
+			if !bytes.Equal(got, again) {
+				t.Fatalf("formatting is not idempotent:\nonce:\n%q\ntwice:\n%q", string(got), string(again))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add top-level `af fmt` with stdout, `--write`, `--check`, and `--dir` modes.
- Add `pkg/format.Format` for conservative, idempotent `.af` formatting driven by fine-grained tokens.
- Normalize `.title` spacing, directive spacing, structural title blank lines, line endings, trailing whitespace, and final newlines without reflowing prose or indenting conditional bodies.

Closes #72.

## Tests

- `go test ./...`
- `go run ./cmd/af fmt --write "$tmpdir/prompt.af" && go run ./cmd/af fmt --check "$tmpdir/prompt.af" && go run ./cmd/af fmt "$tmpdir/prompt.af"`
