### PR TITLE
feat(lint): add af lint command

### DIFF
--- a/cmd/af/lint/lint.go
+++ b/cmd/af/lint/lint.go
@@ -1,0 +1,142 @@
+/*
+Copyright © 2024 Omni Aura peyton@omniaura.co
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package lintcmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/omniaura/agentflow/pkg/assert"
+	"github.com/omniaura/agentflow/pkg/lint"
+	"github.com/spf13/cobra"
+)
+
+var output io.Writer = os.Stdout
+
+type options struct {
+	dir    string
+	format string
+}
+
+func CMD() *cobra.Command {
+	opts := &options{format: "text"}
+	cmd := &cobra.Command{
+		Use:   "lint <files...>",
+		Short: "Lint .af files",
+		Args: func(cmd *cobra.Command, args []string) error {
+			return opts.validate(args)
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			assert.NoError(run(opts, args))
+		},
+	}
+	cmd.Flags().StringVar(&opts.dir, "dir", "", "Recursively lint .af files in a directory")
+	cmd.Flags().StringVar(&opts.format, "format", "text", "Output format: text or json")
+	return cmd
+}
+
+func (opts options) validate(args []string) error {
+	if opts.format != "text" && opts.format != "json" {
+		return fmt.Errorf("unknown lint output format %q", opts.format)
+	}
+	if opts.dir != "" && len(args) > 0 {
+		return fmt.Errorf("--dir cannot be combined with explicit files")
+	}
+	if opts.dir == "" && len(args) == 0 {
+		return fmt.Errorf("provide files or --dir")
+	}
+	return nil
+}
+
+func run(opts *options, args []string) error {
+	files := args
+	if opts.dir != "" {
+		var err error
+		files, err = collectAFFiles(opts.dir)
+		if err != nil {
+			return err
+		}
+	}
+
+	var diagnostics []lint.Diagnostic
+	for _, file := range files {
+		src, err := os.ReadFile(file)
+		if err != nil {
+			return err
+		}
+		fileDiagnostics, err := lint.Lint(file, src)
+		if err != nil {
+			return err
+		}
+		diagnostics = append(diagnostics, fileDiagnostics...)
+	}
+
+	if opts.format == "json" {
+		encoded, err := json.MarshalIndent(diagnostics, "", "  ")
+		if err != nil {
+			return err
+		}
+		if _, err := output.Write(append(encoded, '\n')); err != nil {
+			return err
+		}
+	} else {
+		for _, diagnostic := range diagnostics {
+			if _, err := fmt.Fprintf(output, "%s:%d:%d: %s %s %s\n", diagnostic.File, diagnostic.Line, diagnostic.Column, diagnostic.Severity, diagnostic.Code, diagnostic.Message); err != nil {
+				return err
+			}
+		}
+	}
+
+	if hasErrors(diagnostics) {
+		return fmt.Errorf("lint found errors")
+	}
+	return nil
+}
+
+func hasErrors(diagnostics []lint.Diagnostic) bool {
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Severity == lint.SeverityError {
+			return true
+		}
+	}
+	return false
+}
+
+func collectAFFiles(dir string) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.Type()&fs.ModeSymlink != 0 {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !d.IsDir() && filepath.Ext(path) == ".af" {
+			files = append(files, path)
+		}
+		return nil
+	})
+	sort.Strings(files)
+	return files, err
+}

--- a/cmd/af/lint/lint_test.go
+++ b/cmd/af/lint/lint_test.go
@@ -1,0 +1,66 @@
+package lintcmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omniaura/agentflow/pkg/assert/require"
+	"github.com/omniaura/agentflow/pkg/lint"
+)
+
+func TestRunExplicitFileSuccess(t *testing.T) {
+	path := writeFile(t, t.TempDir(), "ok.af", ".title Ok\nBody\n")
+	require.NoError(t, run(&options{format: "text"}, []string{path}))
+}
+
+func TestRunDirtyFileFailsAndPrintsDiagnostics(t *testing.T) {
+	path := writeFile(t, t.TempDir(), "bad.af", ".title Bad\n</x>\n")
+	originalOutput := output
+	var out bytes.Buffer
+	output = &out
+	t.Cleanup(func() { output = originalOutput })
+
+	err := run(&options{format: "text"}, []string{path})
+	if err == nil {
+		t.Fatal("expected lint failure")
+	}
+	if !strings.Contains(out.String(), "AF002") {
+		t.Fatalf("expected AF002 output, got %q", out.String())
+	}
+}
+
+func TestRunDirWalksAFFiles(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "a.af", ".title A\nBody\n")
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "nested"), 0755))
+	writeFile(t, filepath.Join(dir, "nested"), "b.af", ".title B\nBody\n")
+	writeFile(t, dir, "ignore.txt", "No title\n")
+
+	require.NoError(t, run(&options{format: "text", dir: dir}, nil))
+}
+
+func TestRunJSONOutput(t *testing.T) {
+	path := writeFile(t, t.TempDir(), "bad.af", ".title Bad\n</x>\n")
+	originalOutput := output
+	var out bytes.Buffer
+	output = &out
+	t.Cleanup(func() { output = originalOutput })
+
+	_ = run(&options{format: "json"}, []string{path})
+	var diagnostics []lint.Diagnostic
+	require.NoError(t, json.Unmarshal(out.Bytes(), &diagnostics))
+	if len(diagnostics) != 1 || diagnostics[0].Code != "AF002" {
+		t.Fatalf("unexpected diagnostics: %#v", diagnostics)
+	}
+}
+
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	return path
+}

--- a/cmd/af/main.go
+++ b/cmd/af/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/omniaura/agentflow/cmd/af/demo"
 	fmtcmd "github.com/omniaura/agentflow/cmd/af/fmt"
 	"github.com/omniaura/agentflow/cmd/af/gen"
+	lintcmd "github.com/omniaura/agentflow/cmd/af/lint"
 	"github.com/omniaura/agentflow/cmd/af/lsp"
 	"github.com/omniaura/agentflow/pkg/assert"
 	"github.com/omniaura/agentflow/pkg/logger"
@@ -42,6 +43,7 @@ func newRootCommand() *cobra.Command {
 	root.AddCommand(demo.CMD())
 	root.AddCommand(fmtcmd.CMD())
 	root.AddCommand(gen.CMD())
+	root.AddCommand(lintcmd.CMD())
 	root.AddCommand(lsp.CMD())
 
 	// Bind persistent flags to viper after all commands are added.

--- a/cmd/af/main_test.go
+++ b/cmd/af/main_test.go
@@ -45,11 +45,14 @@ func TestNewRootCommandDefaults(t *testing.T) {
 	if _, _, err := cmd.Find([]string{"gen"}); err != nil {
 		t.Fatalf("expected gen subcommand, got error %v", err)
 	}
+	if _, _, err := cmd.Find([]string{"lint"}); err != nil {
+		t.Fatalf("expected lint subcommand, got error %v", err)
+	}
 	if _, _, err := cmd.Find([]string{"lsp"}); err != nil {
 		t.Fatalf("expected lsp subcommand, got error %v", err)
 	}
-	if len(cmd.Commands()) != 4 {
-		t.Fatalf("expected 4 subcommands, got %d", len(cmd.Commands()))
+	if len(cmd.Commands()) != 5 {
+		t.Fatalf("expected 5 subcommands, got %d", len(cmd.Commands()))
 	}
 }
 

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -1,0 +1,321 @@
+/*
+Copyright © 2024 Omni Aura peyton@omniaura.co
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package lint
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/omniaura/agentflow/pkg/token"
+	"github.com/omniaura/agentflow/pkg/token/kind"
+	"github.com/peyton-spencer/caseconv/bytcase"
+)
+
+type Severity string
+
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+)
+
+type Diagnostic struct {
+	File     string   `json:"file"`
+	Line     int      `json:"line"`
+	Column   int      `json:"column"`
+	Severity Severity `json:"severity"`
+	Code     string   `json:"code"`
+	Message  string   `json:"message"`
+}
+
+type frame struct {
+	path    string
+	tok     token.T
+	sawElse bool
+}
+
+var identifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+var symbolicConditionalPattern = regexp.MustCompile(`<\?[^\n>]*(>=|<=|==|!=)`)
+
+func Lint(name string, src []byte) ([]Diagnostic, error) {
+	tokens, err := token.Tokenize(src)
+	if err != nil {
+		return nil, err
+	}
+
+	l := &linter{name: name, src: src, lineStarts: lineStarts(src)}
+	l.checkRawSymbolicOperators()
+	l.check(tokens)
+	return l.diagnostics, nil
+}
+
+func (l *linter) checkRawSymbolicOperators() {
+	for _, loc := range symbolicConditionalPattern.FindAllIndex(l.src, -1) {
+		l.add(token.T{Start: loc[0], End: loc[1]}, SeverityError, "AF009", "invalid symbolic comparison operator")
+	}
+}
+
+type linter struct {
+	name        string
+	src         []byte
+	lineStarts  []int
+	diagnostics []Diagnostic
+	stack       []frame
+	types       map[string]string
+	titles      map[string]token.T
+	hasTitle    bool
+	hasContent  bool
+}
+
+func (l *linter) check(tokens token.Slice) {
+	l.types = make(map[string]string)
+	l.titles = make(map[string]token.T)
+
+	for i := 0; i < len(tokens); i++ {
+		tok := tokens[i]
+		switch tok.Kind {
+		case kind.TitleDirective:
+			i = l.checkTitle(tokens, i)
+		case kind.Text:
+			if strings.TrimSpace(string(tok.Get(l.src))) != "" {
+				l.hasContent = true
+			}
+		case kind.OpenBracket:
+			i = l.checkDirective(tokens, i)
+		}
+	}
+
+	for _, f := range l.stack {
+		l.add(f.tok, SeverityError, "AF003", fmt.Sprintf("unclosed conditional <?%s>", f.path))
+	}
+	if !l.hasTitle && l.hasContent {
+		l.add(token.T{Start: 0, End: 0}, SeverityError, "AF001", "file has content but no .title section")
+	}
+}
+
+func (l *linter) checkTitle(tokens token.Slice, start int) int {
+	l.hasTitle = true
+	i := start + 1
+	if i < len(tokens) && tokens[i].Kind == kind.Whitespace && !strings.Contains(string(tokens[i].Get(l.src)), "\n") {
+		i++
+	}
+
+	if i >= len(tokens) || tokens[i].Kind != kind.TitleText || strings.TrimSpace(string(tokens[i].Get(l.src))) == "" {
+		l.add(tokens[start], SeverityWarning, "AF103", "empty title")
+		return start
+	}
+
+	title := strings.TrimSpace(string(tokens[i].Get(l.src)))
+	generated := string(bytcase.ToCamel([]byte(title)))
+	if first, ok := l.titles[generated]; ok {
+		_ = first
+		l.add(tokens[i], SeverityWarning, "AF102", fmt.Sprintf("duplicate title %q generates %s", title, generated))
+	} else {
+		l.titles[generated] = tokens[i]
+	}
+	return i
+}
+
+func (l *linter) checkDirective(tokens token.Slice, start int) int {
+	if start+1 >= len(tokens) {
+		return start
+	}
+	switch tokens[start+1].Kind {
+	case kind.DirectiveVar:
+		return l.checkVar(tokens, start)
+	case kind.DirectiveCond:
+		return l.checkCond(tokens, start)
+	case kind.DirectiveEnd:
+		return l.checkEnd(tokens, start)
+	case kind.DirectiveElse:
+		return l.checkElse(tokens, start)
+	default:
+		return start
+	}
+}
+
+func (l *linter) checkVar(tokens token.Slice, start int) int {
+	end, content := l.directiveContent(tokens, start)
+	l.hasContent = true
+	parts := strings.Fields(content)
+	if len(parts) == 0 {
+		l.add(tokens[start], SeverityWarning, "AF104", "empty variable directive")
+		return end
+	}
+	l.checkPath(tokens[start], parts[0])
+	if len(parts) > 1 {
+		l.checkType(tokens[start], parts[0], parts[1])
+	}
+	return end
+}
+
+func (l *linter) checkCond(tokens token.Slice, start int) int {
+	end, content := l.directiveContent(tokens, start)
+	l.hasContent = true
+	parts := strings.Fields(content)
+	if len(parts) == 0 {
+		l.add(tokens[start], SeverityWarning, "AF104", "empty conditional directive")
+		return end
+	}
+
+	path := parts[0]
+	l.checkPath(tokens[start], path)
+	if len(parts) == 2 {
+		if isSymbolicOperator(parts[1]) {
+			l.add(tokens[start], SeverityError, "AF009", fmt.Sprintf("invalid comparison operator %q", parts[1]))
+		} else {
+			l.checkType(tokens[start], path, parts[1])
+		}
+	} else if len(parts) >= 3 {
+		if isSymbolicOperator(parts[1]) || !isOperator(parts[1]) {
+			l.add(tokens[start], SeverityError, "AF009", fmt.Sprintf("invalid comparison operator %q", parts[1]))
+		}
+	}
+	l.stack = append(l.stack, frame{path: path, tok: tokens[start]})
+	return end
+}
+
+func (l *linter) checkEnd(tokens token.Slice, start int) int {
+	end, content := l.directiveContent(tokens, start)
+	l.hasContent = true
+	parts := strings.Fields(content)
+	if len(parts) == 0 {
+		l.add(tokens[start], SeverityWarning, "AF104", "empty end directive")
+		return end
+	}
+	path := parts[0]
+	l.checkPath(tokens[start], path)
+	if len(l.stack) == 0 {
+		l.add(tokens[start], SeverityError, "AF002", fmt.Sprintf("unmatched end tag </%s>", path))
+		return end
+	}
+	top := l.stack[len(l.stack)-1]
+	l.stack = l.stack[:len(l.stack)-1]
+	if top.path != path {
+		l.add(tokens[start], SeverityError, "AF004", fmt.Sprintf("mismatched conditional close: opened <?%s> but closed </%s>", top.path, path))
+	}
+	return end
+}
+
+func (l *linter) checkElse(tokens token.Slice, start int) int {
+	end, _ := l.directiveContent(tokens, start)
+	l.hasContent = true
+	if len(l.stack) == 0 {
+		l.add(tokens[start], SeverityError, "AF006", "else outside conditional")
+		return end
+	}
+	top := &l.stack[len(l.stack)-1]
+	if top.sawElse {
+		l.add(tokens[start], SeverityError, "AF005", fmt.Sprintf("duplicate else in conditional <?%s>", top.path))
+	}
+	top.sawElse = true
+	return end
+}
+
+func (l *linter) directiveContent(tokens token.Slice, start int) (int, string) {
+	end := start
+	for end < len(tokens) && tokens[end].Kind != kind.CloseBracket {
+		end++
+	}
+	if end >= len(tokens) {
+		return start, ""
+	}
+	contentStart := tokens[start+2].Start
+	contentEnd := tokens[end].Start
+	if contentEnd < contentStart {
+		contentEnd = contentStart
+	}
+	return end, string(l.src[contentStart:contentEnd])
+}
+
+func (l *linter) checkPath(tok token.T, path string) {
+	if !validPath(path) {
+		l.add(tok, SeverityError, "AF007", fmt.Sprintf("invalid variable path %q", path))
+	}
+}
+
+func (l *linter) checkType(tok token.T, path, typ string) {
+	if !validType(typ) {
+		l.add(tok, SeverityError, "AF008", fmt.Sprintf("invalid type annotation %q", typ))
+		return
+	}
+	if previous, ok := l.types[path]; ok && previous != typ {
+		l.add(tok, SeverityWarning, "AF101", fmt.Sprintf("variable %q has inconsistent type annotations %q and %q", path, previous, typ))
+		return
+	}
+	l.types[path] = typ
+}
+
+func (l *linter) add(tok token.T, severity Severity, code, message string) {
+	line, column := position(l.lineStarts, tok.Start)
+	l.diagnostics = append(l.diagnostics, Diagnostic{File: l.name, Line: line, Column: column, Severity: severity, Code: code, Message: message})
+}
+
+func lineStarts(src []byte) []int {
+	starts := []int{0}
+	for i, b := range src {
+		if b == '\n' {
+			starts = append(starts, i+1)
+		}
+	}
+	return starts
+}
+
+func position(starts []int, offset int) (int, int) {
+	line := 0
+	for i := range starts {
+		if starts[i] > offset {
+			break
+		}
+		line = i
+	}
+	return line + 1, offset - starts[line] + 1
+}
+
+func validPath(path string) bool {
+	if path == "" || strings.HasPrefix(path, ".") || strings.HasSuffix(path, ".") || strings.Contains(path, "..") {
+		return false
+	}
+	for _, part := range strings.Split(path, ".") {
+		if !identifierPattern.MatchString(part) {
+			return false
+		}
+	}
+	return true
+}
+
+func validType(typ string) bool {
+	switch typ {
+	case "string", "int", "bool", "float32", "float64":
+		return true
+	default:
+		return false
+	}
+}
+
+func isOperator(op string) bool {
+	switch op {
+	case "eq", "ne", "gt", "lt", "gte", "lte":
+		return true
+	default:
+		return false
+	}
+}
+
+func isSymbolicOperator(op string) bool {
+	return bytes.ContainsAny([]byte(op), "=<>!")
+}

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -1,0 +1,71 @@
+package lint
+
+import (
+	"testing"
+
+	"github.com/omniaura/agentflow/pkg/assert/require"
+)
+
+func TestLintValidFile(t *testing.T) {
+	diagnostics := lintString(t, `.title System Prompt
+Hello <!user.name>.
+
+<?user.premium bool>
+Premium.
+<else>
+Default.
+</user.premium>
+`)
+	if len(diagnostics) != 0 {
+		t.Fatalf("expected no diagnostics, got %#v", diagnostics)
+	}
+}
+
+func TestLintRules(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		code string
+	}{
+		{"no title", "Hello <!user.name>\n", "AF001"},
+		{"unmatched end", ".title Test\n</user.premium>\n", "AF002"},
+		{"unclosed conditional", ".title Test\n<?user.premium>\n", "AF003"},
+		{"mismatched close", ".title Test\n<?user.premium>\n</user.admin>\n", "AF004"},
+		{"duplicate else", ".title Test\n<?user.premium>\n<else>\n<else>\n</user.premium>\n", "AF005"},
+		{"else outside", ".title Test\n<else>\n", "AF006"},
+		{"invalid var path", ".title Test\n<!user..name>\n", "AF007"},
+		{"invalid conditional path", ".title Test\n<?.premium>\n</.premium>\n", "AF007"},
+		{"invalid end path", ".title Test\n</user.>\n", "AF007"},
+		{"invalid type", ".title Test\n<!count float>\n", "AF008"},
+		{"symbolic operator", ".title Test\n<?count >= 3>\n</count>\n", "AF009"},
+		{"inconsistent type", ".title Test\n<!count int> <!count bool>\n", "AF101"},
+		{"duplicate title", ".title Hello User\nOne\n.title hello user\nTwo\n", "AF102"},
+		{"empty title", ".title   \nBody\n", "AF103"},
+		{"empty directive", ".title Test\n<!>\n", "AF104"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diagnostics := lintString(t, tt.src)
+			if !hasCode(diagnostics, tt.code) {
+				t.Fatalf("expected %s, got %#v", tt.code, diagnostics)
+			}
+		})
+	}
+}
+
+func lintString(t *testing.T, src string) []Diagnostic {
+	t.Helper()
+	diagnostics, err := Lint("test.af", []byte(src))
+	require.NoError(t, err)
+	return diagnostics
+}
+
+func hasCode(diagnostics []Diagnostic, code string) bool {
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Code == code {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Add reusable `pkg/lint.Lint(name, src)` diagnostics API with severity, code, file, line, and column metadata.
- Add top-level `af lint` supporting explicit files, recursive `--dir`, and `--format text|json` output.
- Implement v1 structural/objective diagnostics from #75: conditional matching errors, invalid paths/types/operators, no title, inconsistent type warnings, duplicate title warnings, empty titles, and empty directives.

Closes #75.

## Tests

- `go test ./...`
- `go run ./cmd/af lint "$tmpdir/ok.af"`
- `go run ./cmd/af lint "$tmpdir/bad.af"`
- `go run ./cmd/af lint --format json "$tmpdir/bad.af"`
- `go run ./cmd/af lint --dir "$tmpdir"`
